### PR TITLE
Update polaris version to 0.7.7

### DIFF
--- a/org-Biogen/fang2023_ADME/env.yml
+++ b/org-Biogen/fang2023_ADME/env.yml
@@ -5,7 +5,7 @@ dependencies:
   # scientific
   - rdkit == 2023.9.6
   - auroris == 0.1.3
-  - polaris == 0.5.1
+  - polaris == 0.7.7
 
   # visualization
   - umap-learn==0.5.5

--- a/org-Graphium/env.yml
+++ b/org-Graphium/env.yml
@@ -5,7 +5,7 @@ dependencies:
   # scientific
   - rdkit == 2023.9.6
   - auroris == 0.1.3
-  - polaris == 0.5.1
+  - polaris == 0.7.7
 
   # visualization
   - umap-learn==0.5.5

--- a/org-Novartis/CYP/env.yml
+++ b/org-Novartis/CYP/env.yml
@@ -5,7 +5,7 @@ dependencies:
   # scientific
   - rdkit == 2023.9.6
   - auroris == 0.1.3
-  - polaris == 0.5.1
+  - polaris == 0.7.7
 
   # visualization
   - umap-learn==0.5.5

--- a/org-TDC/env.yml
+++ b/org-TDC/env.yml
@@ -5,7 +5,7 @@ dependencies:
   # scientific
   - rdkit == 2023.9.6
   - auroris == 0.1.3
-  - polaris == 0.5.1
+  - polaris == 0.7.7
   - pytdc
   
   # visualization


### PR DESCRIPTION
This PR update the polaris version to 0.7.7 which is important to maintain the correct names for the most recent added datasets and benchmarks.